### PR TITLE
Added webhook example

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -8,9 +8,6 @@ const bodyParser = require('body-parser');
 const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY);
 const app = express();
 
-// Load environment variables from the `.env` file.
-require('dotenv').config();
-
 // we've started you off with Express,
 // but feel free to use whatever libs or frameworks you'd like through `package.json`.
 
@@ -56,28 +53,41 @@ app.get('/config', (req, res) => {
  * Webhook example
  *
  * To test this, use ngrok to make the app publically available, then add the URL to your webhook settings here: https://dashboard.stripe.com/account/webhooks
- * Make sure you added the webhook secret to your .env file, then click the "Send test webhook" button in your webhook configuration page
+ * Make sure you added the webhook secret to your .env file, then click the "Send test webhook" button in your webhook configuration page.
  */
 const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
 
-app.post('/webhooks', bodyParser.raw({type: 'application/json'}), (req, res) => {
-  const sig = req.headers['stripe-signature'];
+app.post(
+  '/webhooks',
+  bodyParser.raw({type: 'application/json'}),
+  (req, res) => {
+    const sig = req.headers['stripe-signature'];
 
-  let event;
+    let event;
 
-  try {
-    event = stripe.webhooks.constructEvent(req.body, sig, webhookSecret);
-  } catch  (err) {
-     // On error, return the error message
-     return res.status(500).send(`Webhook Error: ${err.message}`);
+    try {
+      event = stripe.webhooks.constructEvent(req.body, sig, webhookSecret);
+    } catch (err) {
+      console.log(
+        `⚠️  Webhook signature verification failed. Please check your webhook secret in the .env file.`
+      );
+      // On error, return the error message.
+      return res.status(400).send(`Webhook Error: ${err.message}`);
+    }
+
+    // Extract the object from the event.
+    const dataObject = event.data.object;
+    // Do something with the event and its data.
+    console.log(
+      `🔔  Webhook for event ${event.id} of type ${
+        event.type
+      } received! It contains an object of type ${dataObject.object}.`
+    );
+
+    // Return a response to acknowledge receipt of the event.
+    res.json({received: true});
   }
-
-  // Do something with event
-  console.log('Success:', event.id);
-
-  // Return a response to acknowledge receipt of the event
-  res.json({received: true});
-});
+);
 
 // listen for requests :)
 const server = app.listen(port, function() {

--- a/dev.js
+++ b/dev.js
@@ -6,11 +6,7 @@ require('dotenv').config();
 
 const port = parseInt(process.env.PORT, 10);
 ngrok
-  .connect({
-    proto: 'http',
-    addr: port,
-    host_header: `localhost:${port}`
-  })
+  .connect(port)
   .then(url => {
     nodemon(`-x 'NGROK_URL=${url} PORT=${port} node' ./backend/server.js`);
     if (port === 3000) {

--- a/dev.js
+++ b/dev.js
@@ -11,7 +11,7 @@ ngrok
     nodemon(`-x 'NGROK_URL=${url} PORT=${port} node' ./backend/server.js`);
     if (port === 3000) {
       opn(url);
-      console.log(`🌍 Available online: ${url}`);
+      console.log(`🌍 Available online: ${url}/`);
     }
     console.log(`👩🏻‍💻  Webhook URL for Stripe: ${url}/webhooks`);
   })

--- a/dev.js
+++ b/dev.js
@@ -6,14 +6,18 @@ require('dotenv').config();
 
 const port = parseInt(process.env.PORT, 10);
 ngrok
-  .connect(port)
+  .connect({
+    proto: 'http',
+    addr: port,
+    host_header: `localhost:${port}`
+  })
   .then(url => {
     nodemon(`-x 'NGROK_URL=${url} PORT=${port} node' ./backend/server.js`);
     if (port === 3000) {
       opn(url);
       console.log(`🌍 Available online: ${url}`);
     }
-    console.log(`👩🏻‍💻  Webhook URL for Stripe: ${url}/webhook`);
+    console.log(`👩🏻‍💻  Webhook URL for Stripe: ${url}/webhooks`);
   })
   .catch(err => {
     throw err;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2186,6 +2186,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
     "lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
@@ -3359,6 +3364,24 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
+    "stripe": {
+      "version": "6.31.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-6.31.0.tgz",
+      "integrity": "sha512-VHVGyfrnzKdqraRHKQ42LJysQdg2iUL8pFES3dsN9yZOiEY+kxBetL7Zq2WiA24Y5PnVIO9gB5VbvmYPhEOhyA==",
+      "requires": {
+        "lodash.isplainobject": "^4.0.6",
+        "qs": "^6.6.0",
+        "safe-buffer": "^5.1.1",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+        }
+      }
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -3663,8 +3686,7 @@
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "dev": true
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "concurrently": "^4.1.0",
     "dotenv": "^4.0.0",
-    "express": "^4.16.4"
+    "express": "^4.16.4",
+    "stripe": "^6.31.0"
   },
   "engines": {
     "node": "8.x"


### PR DESCRIPTION
Adds a webhook example, mimics what we're doing over in stripe-node [here](https://github.com/stripe/stripe-node/pull/599). Fixes https://github.com/thorsten-stripe/js-workshop/issues/3

~TODO: This only really works when using ngrok as the server needs to be publicly accessible, we should figure out how to get ngrok working nicely with the react frontend.~

Turns out this works with the current implementation, you just need to grab the ngrok URL from the console.

