### PR TITLE
Add easy config loading for vanilla and got rid of dangerous npm scripts

### DIFF
--- a/dev.js
+++ b/dev.js
@@ -5,6 +5,7 @@ const opn = require('opn');
 require('dotenv').config();
 
 const port = parseInt(process.env.PORT, 10);
+
 ngrok
   .connect(port)
   .then(url => {

--- a/frontend/reactjs/README.md
+++ b/frontend/reactjs/README.md
@@ -27,16 +27,6 @@ Your app is ready to be deployed!
 
 See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
 
-### `npm run eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
-
-If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (Webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
-
-You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
-
 ## Learn More
 
 You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).

--- a/frontend/reactjs/package.json
+++ b/frontend/reactjs/package.json
@@ -11,8 +11,7 @@
   "scripts": {
     "start": "export HTTPS=true && react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "test": "react-scripts test"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/frontend/vanilla/index.js
+++ b/frontend/vanilla/index.js
@@ -1,6 +1,27 @@
-// Init Stripe.js
+class StripeWorkshop {
+  constructor(config) {
+    if (typeof config === 'undefined') {
+      throw new Error('Cannot be called directly.');
+    }
 
-const preorderButton = document.querySelector('.pre-order');
-preorderButton.addEventListener('click', e => {
-  // Implement functionality.
+    // Init Stripe.js
+    this.stripe = Stripe(config.stripePublishableKey);
+  }
+
+  static async build() {
+    const config = await fetch(`/config`).then(r => r.json());
+    return new StripeWorkshop(config);
+  }
+
+  addListeners() {
+    const preorderButton = document.querySelector('.pre-order');
+    preorderButton.addEventListener('click', e => {
+      // Implement functionality.
+      console.log('foo');
+    });
+  }
+}
+
+StripeWorkshop.build().then((stripeWorkshop) => {
+  stripeWorkshop.addListeners();
 });

--- a/frontend/vanilla/index.js
+++ b/frontend/vanilla/index.js
@@ -8,14 +8,11 @@ async function main() {
   const preorderButton = document.querySelector('.pre-order');
   preorderButton.addEventListener('click', e => {
     // Implement functionality.
-    console.log('foo');
   });
 }
 
 async function getConfig() {
-  const config = await fetch(`/config`).then(r => r.json());
-
-  return config;
+  return await fetch(`/config`).then(r => r.json());
 }
 
-main();
+window.onload = main();

--- a/frontend/vanilla/index.js
+++ b/frontend/vanilla/index.js
@@ -15,4 +15,4 @@ async function getConfig() {
   return await fetch(`/config`).then(r => r.json());
 }
 
-window.onload = main();
+window.onload = main;

--- a/frontend/vanilla/index.js
+++ b/frontend/vanilla/index.js
@@ -1,27 +1,21 @@
-class StripeWorkshop {
-  constructor(config) {
-    if (typeof config === 'undefined') {
-      throw new Error('Cannot be called directly.');
-    }
+let stripe;
 
-    // Init Stripe.js
-    this.stripe = Stripe(config.stripePublishableKey);
-  }
+async function main() {
+  const config = await getConfig();
 
-  static async build() {
-    const config = await fetch(`/config`).then(r => r.json());
-    return new StripeWorkshop(config);
-  }
+  stripe = Stripe(config.stripePublishableKey);
 
-  addListeners() {
-    const preorderButton = document.querySelector('.pre-order');
-    preorderButton.addEventListener('click', e => {
-      // Implement functionality.
-      console.log('foo');
-    });
-  }
+  const preorderButton = document.querySelector('.pre-order');
+  preorderButton.addEventListener('click', e => {
+    // Implement functionality.
+    console.log('foo');
+  });
 }
 
-StripeWorkshop.build().then((stripeWorkshop) => {
-  stripeWorkshop.addListeners();
-});
+async function getConfig() {
+  const config = await fetch(`/config`).then(r => r.json());
+
+  return config;
+}
+
+main();


### PR DESCRIPTION
Got rid of `npm run eject` as we really don't want someone accidentally running that during the workshop since it's a one-way operation.

Also changed vanilla entry point a bit to load the config values from the backend like how the react frontend does.

r? @thorsten-stripe @ctrudeau-stripe 